### PR TITLE
Make proofs a bit smaller

### DIFF
--- a/lean_proofs/LeanProofs/FibFibFastProof.lean
+++ b/lean_proofs/LeanProofs/FibFibFastProof.lean
@@ -14,35 +14,20 @@ def fib_fib_fast_proof : fib_fib_fast := by
   intro n ; intros
   and_intros
   · intros
+    unfold k0 k1 k2 at *;
     and_intros
-    · intros idx idx_eq prev prev_eq curr curr_eq
+    · intros
+      and_intros <;>
+        grind [fib_fib_eq, fib_rec]
+    · intro idx ; intros
       and_intros
-      · omega
-      · omega
-      · simp [fib_fib_eq]
-        unfold fib_rec fib_rec
-        simp [idx_eq] ; assumption
-      · simp [fib_fib_eq]
-        unfold fib_rec fib_rec
-        simp [idx_eq] ; assumption
-      · trivial
-      · trivial
-    · intros idx prev curr _ ks_hold
-      unfold k0 at ks_hold ; have k0_holds := ks_hold.left ; clear ks_hold
-      and_intros
-      · intros _ idx_ge_n
+      · intros
         have idx_eq_n : idx = n := by omega
         rw [←idx_eq_n]
         omega
       · intros _ idx_lt_n next_idx next_idx_eq next_fib next_fib_eq
-        and_intros
-        · omega
-        · omega
-        · rw [next_fib_eq, next_idx_eq]
-          simp [k0_holds, fib_fib_eq]
-          conv => rhs; unfold fib_rec
-          grind
-        · simp [next_idx_eq, k0_holds]
-        · trivial
-        · trivial
-  · intros ; simp [fib_fib_eq] ; unfold fib_rec ; grind
+        rw [next_fib_eq, next_idx_eq]
+        simp [fib_fib_eq, *]
+        conv => rhs ; rhs ; rhs ; unfold fib_rec
+        and_intros <;> grind
+  · intros ; grind [fib_fib_eq, fib_rec]

--- a/lean_proofs/LeanProofs/FibFibSlowProof.lean
+++ b/lean_proofs/LeanProofs/FibFibSlowProof.lean
@@ -18,8 +18,5 @@ def fib_fib_slow_proof : fib_fib_slow := by
         have h : ¬ n.natAbs ≤ 1 := by omega
         simp [h]
         grind
-  · intros _ n_le_1
-    simp [fib_fib_eq]
-    unfold fib_rec
-    have h : n.natAbs ≤ 1 := by omega
-    simp [h]
+  · intros
+    grind [fib_fib_eq, fib_rec]


### PR DESCRIPTION
Just using grind to make the proofs smaller. This sort of rewrite feels only useful to make the proof more resilient to small changes in the rust code (e.g. changing the order of the variables or something that would mess with the exact order in which they're introduced) which is otherwise really brittle. One possible strategy would be to annotate every definition around these proofs with `simp` and `grind` and see if it's easier to do the proofs from scratch.